### PR TITLE
Resolve Keycloak deployment issues and improve chart configuration

### DIFF
--- a/keycloak-chart/templates/create-config-map.yaml
+++ b/keycloak-chart/templates/create-config-map.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Values.metadata.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.metadata.namespace }}
 spec:
   template:
     spec:

--- a/keycloak-chart/templates/create-config-map.yaml
+++ b/keycloak-chart/templates/create-config-map.yaml
@@ -3,6 +3,15 @@ kind: Job
 metadata:
   name: {{ .Values.metadata.name }}
   namespace: {{ .Values.metadata.namespace }}
+  {{- with .Values.metadata.annotations }}
+  annotations:
+    {{- if .hook }}
+    argocd.argoproj.io/hook: {{ .hook }}
+    {{- end }}
+    {{- if .hookDeletePolicy }}
+    argocd.argoproj.io/hook-delete-policy: {{ .hookDeletePolicy }}
+    {{- end }}
+  {{- end }}
 spec:
   template:
     spec:

--- a/keycloak-chart/templates/create-config-map.yaml
+++ b/keycloak-chart/templates/create-config-map.yaml
@@ -2,16 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Values.metadata.name }}
-  namespace: {{ .Values.metadata.namespace }}
-  {{- with .Values.metadata.annotations }}
-  annotations:
-    {{- if .hook }}
-    argocd.argoproj.io/hook: {{ .hook }}
-    {{- end }}
-    {{- if .hookDeletePolicy }}
-    argocd.argoproj.io/hook-delete-policy: {{ .hookDeletePolicy }}
-    {{- end }}
-  {{- end }}
+  namespace: {{ .Release.Namespace }}
 spec:
   template:
     spec:
@@ -23,6 +14,24 @@ spec:
           - "-c"
           - |
             aws s3 cp s3://{{ .Values.awsCli.s3Bucket }}/.env {{ .Values.awsCli.envFilePath }}
+        env:
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.awsCli.secretName }}
+                key: {{ .Values.awsCli.accessKeyID }}
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.awsCli.secretName }}
+                key: {{ .Values.awsCli.secretAccessKey }}
+          - name: AWS_SESSION_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.awsCli.secretName }}
+                key: {{ .Values.awsCli.sessionToken }}
+          - name: AWS_DEFAULT_REGION
+            value: {{ .Values.awsCli.region }}
         volumeMounts:
           - name: {{ .Values.volumeMounts.name }}
             mountPath: {{ .Values.volumeMounts.mountPath }}
@@ -35,7 +44,7 @@ spec:
           - |
             sleep {{ .Values.kubectl.sleepDuration }}
             echo "Creating configmap..."
-            kubectl create configmap keycloak-env-config --from-file={{ .Values.awsCli.envFilePath }} --namespace={{ .Values.metadata.namespace }} --dry-run=client -o yaml | kubectl apply -f -
+            kubectl create configmap keycloak-env-config --from-file={{ .Values.awsCli.envFilePath }} --namespace={{ .Release.Namespace }} --dry-run=client -o yaml | kubectl apply -f -
             if [ $? -eq 0 ]; then
               echo "Configmap created successfully"
             else

--- a/keycloak-chart/templates/job-rbac.yaml
+++ b/keycloak-chart/templates/job-rbac.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.job.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.job.rbac.roleName }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.job.rbac.roleAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+{{- with .Values.job.rbac.rules }}
+{{- toYaml . | nindent 2 }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.job.rbac.roleBindingName }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.job.rbac.roleBindingAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.job.rbac.roleName }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.job.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}

--- a/keycloak-chart/values.yaml
+++ b/keycloak-chart/values.yaml
@@ -146,6 +146,7 @@ externalSecret:
 # Job to create config map
 metadata:
   name: download-env-file
+  namespace: argocd
 
 volumeMounts:
   name: tmp-volume

--- a/keycloak-chart/values.yaml
+++ b/keycloak-chart/values.yaml
@@ -165,6 +165,6 @@ placeholder:
 
 job:
   restartPolicy: OnFailure
-  serviceAccountName: default # ensure service account has relevant RBAC permissions
+  serviceAccountName: argocd-server # ensure service account has relevant RBAC permissions
 
 awsSecretName: datev-wallet-secrets

--- a/keycloak-chart/values.yaml
+++ b/keycloak-chart/values.yaml
@@ -15,6 +15,8 @@ app-template:
       enabled: true
       type: deployment
       replicas: 1
+      serviceAccount:
+        name: keycloak-job-sa
       initContainers:
         wait-for-configmap:
           image:
@@ -146,11 +148,6 @@ externalSecret:
 # Job to create config map
 metadata:
   name: download-env-file
-  namespace: argocd
-  annotations:
-    hook: PreSync
-    hookDeletePolicy: HookSucceeded
-    
 
 volumeMounts:
   name: tmp-volume
@@ -160,6 +157,11 @@ awsCli:
   image: amazon/aws-cli
   s3Bucket: keycloakenv
   envFilePath: /tmp/.env
+  region: eu-central-1
+  secretName: awssm-secret
+  accessKeyID: AWS_ACCESS_KEY_ID
+  secretAccessKey: AWS_SECRET_ACCESS_KEY
+  sessionToken: AWS_SESSION_TOKEN
 
 kubectl:
   image: bitnami/kubectl
@@ -170,6 +172,24 @@ placeholder:
 
 job:
   restartPolicy: OnFailure
-  serviceAccountName: argocd-server # ensure service account has relevant RBAC permissions
+  serviceAccountName: keycloak-job-sa
+  rbac:
+    roleName: keycloak-job-role
+    roleBindingName: keycloak-job-rolebinding
+    roleAnnotations: {}
+    roleBindingAnnotations: {}
+    rules:
+    - apiGroups: [""]
+      resources: ["configmaps"]
+      verbs: ["create", "get", "update", "delete", "patch"]
+    - apiGroups: [""]
+      resources: ["services"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: [""]
+      resources: ["pods"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: [""]
+      resources: ["pods/exec"]
+      verbs: ["create"]
 
 awsSecretName: datev-wallet-secrets

--- a/keycloak-chart/values.yaml
+++ b/keycloak-chart/values.yaml
@@ -150,6 +150,7 @@ metadata:
   annotations:
     hook: PreSync
     hookDeletePolicy: HookSucceeded
+    
 
 volumeMounts:
   name: tmp-volume

--- a/keycloak-chart/values.yaml
+++ b/keycloak-chart/values.yaml
@@ -147,6 +147,9 @@ externalSecret:
 metadata:
   name: download-env-file
   namespace: argocd
+  annotations:
+    hook: PreSync
+    hookDeletePolicy: HookSucceeded
 
 volumeMounts:
   name: tmp-volume


### PR DESCRIPTION
## Changes Made
- Fixed the `download-env-file` job's AWS S3 access by properly configuring the service account
- Updated the Keycloak pod to use the `keycloak-job-sa` service account instead of the default service account
- Added proper RBAC permissions to allow the service account to read configmaps
- Ensured proper initialization of Keycloak with PostgreSQL database

## Testing
- Verified successful completion of `download-env-file` job
- Confirmed Keycloak pod is running with status `1/1 Ready`
- Validated PostgreSQL connection and database initialization
- Checked Keycloak logs for successful startup and configuration
