### PR TITLE
Update certificate generation script to include SANs

### DIFF
--- a/generate-kc-certs.sh
+++ b/generate-kc-certs.sh
@@ -3,6 +3,7 @@
 . load_env.sh
 
 openssl req -newkey rsa:2048 -nodes \
-  -keyout $KC_SERVER_KEY -x509 -days 3650 -out $KC_SERVER_CERT -config $WORK_DIR/cert-config.txt
+  -keyout $KC_SERVER_KEY -x509 -days 3650 -out $KC_SERVER_CERT -config $WORK_DIR/cert-config.txt \
+  -extensions v3_req
   
 keytool -importcert -trustcacerts -noprompt -alias localhost -file $KC_SERVER_CERT -keystore $KC_TRUST_STORE -storepass $KC_TRUST_STORE_PASS


### PR DESCRIPTION
Subject alternative names (SANs) were previously not taken into account because support for extensions must be flagged explicitly.

Additionally, we add Minikube's common host address as a SAN for the certificate to be valid when the server is accessed from the cluster.