### PR TITLE
chore: update images for keycloak

### DIFF
--- a/keycloak-chart/values.yaml
+++ b/keycloak-chart/values.yaml
@@ -47,7 +47,7 @@ app-template:
         main:
           image:
             repository: ghcr.io/adorsys/keycloak-ssi-deployment
-            tag: latest@sha256:745a24f29e9c30c5a005b1ed05e806f50633d483e4715c124a3e12deccf6d61c
+            tag: latest@sha256:639d908c1be84cc2fca2b76e5b98b53c9d7ec68318e6588e424ed114dcc193fb
             pullPolicy: Always
           ports:
           - name: https


### PR DESCRIPTION
This pull request updates container images for the application, as detected by **Argo CD Image Updater**.

**Changes:**
- chore: updated image adorsys/keycloak-ssi-deployment from 'sha256:745a24f29e9c30c5a005b1ed05e806f50633d483e4715c124a3e12deccf6d61c' to 'sha256:639d908c1be84cc2fca2b76e5b98b53c9d7ec68318e6588e424ed114dcc193fb'

Signed-off-by: Argo CD Image Updater <ci@adorsys.com>