### PR TITLE
chore: update images for keycloak

### DIFF
--- a/keycloak-chart/values.yaml
+++ b/keycloak-chart/values.yaml
@@ -47,7 +47,7 @@ app-template:
         main:
           image:
             repository: ghcr.io/adorsys/keycloak-ssi-deployment
-            tag: latest@sha256:4b725c36cda8aced16b4af2905e4dd3ee45c24341754757ac97430a5274bf511
+            tag: latest@sha256:b64db5f950f5dc6fcef143e5f70f396eacaa0ad98b6b860aad3c9635a11b736d
             pullPolicy: Always
           ports:
           - name: https


### PR DESCRIPTION
This pull request updates container images for the application, as detected by **Argo CD Image Updater**.

**Changes:**
- chore: updated image adorsys/keycloak-ssi-deployment from 'sha256:4b725c36cda8aced16b4af2905e4dd3ee45c24341754757ac97430a5274bf511' to 'sha256:b64db5f950f5dc6fcef143e5f70f396eacaa0ad98b6b860aad3c9635a11b736d'

Signed-off-by: Argo CD Image Updater <ci@adorsys.com>