### PR TITLE
chore: update images for keycloak

### DIFF
--- a/keycloak-chart/values.yaml
+++ b/keycloak-chart/values.yaml
@@ -47,7 +47,7 @@ app-template:
         main:
           image:
             repository: ghcr.io/adorsys/keycloak-ssi-deployment
-            tag: latest@sha256:969afa897f6ba70c8127e407bc9253ddf91a517f987f7524fbbe0274adc0e5f8
+            tag: latest@sha256:2a8fe13d9e99bd8ebbedf91f807d9faded0784719bd3973d7bc3360bee34ae8d
             pullPolicy: Always
           ports:
           - name: https


### PR DESCRIPTION
This pull request updates container images for the application, as detected by **Argo CD Image Updater**.

**Changes:**
- chore: updated image adorsys/keycloak-ssi-deployment from 'sha256:969afa897f6ba70c8127e407bc9253ddf91a517f987f7524fbbe0274adc0e5f8' to 'sha256:2a8fe13d9e99bd8ebbedf91f807d9faded0784719bd3973d7bc3360bee34ae8d'

Signed-off-by: Argo CD Image Updater <ci@adorsys.com>