### PR TITLE
chore: update images for keycloak

### DIFF
--- a/keycloak-chart/values.yaml
+++ b/keycloak-chart/values.yaml
@@ -1,7 +1,9 @@
+global:
+  security:
+    allowInsecureImages: true
+
 app-template:
   global:
-    security:
-      allowInsecureImages: true
     fullnameOverride: keycloak
     namespaceOverride: datev-wallet
     labels:

--- a/keycloak-chart/values.yaml
+++ b/keycloak-chart/values.yaml
@@ -1,5 +1,7 @@
 app-template:
   global:
+  security:
+    allowInsecureImages: true
     fullnameOverride: keycloak
     namespaceOverride: datev-wallet
     labels:

--- a/keycloak-chart/values.yaml
+++ b/keycloak-chart/values.yaml
@@ -111,6 +111,10 @@ app-template:
 # Postgresql Configuration
 postgresql:
   enabled: true
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
+    tag: 17.4.0-debian-12-r2
   auth:
     database: keycloakdb
     username: datevadmin

--- a/keycloak-chart/values.yaml
+++ b/keycloak-chart/values.yaml
@@ -47,7 +47,7 @@ app-template:
         main:
           image:
             repository: ghcr.io/adorsys/keycloak-ssi-deployment
-            tag: latest@sha256:609b6526384becbb1a95a0c5f896f56cd88d712eff202a573cb4db2d21969d06
+            tag: latest@sha256:21a27509e3eb863768f5cee03b838cf881574fa10e8faf35181fd798935f09d9
             pullPolicy: Always
           ports:
           - name: https

--- a/keycloak-chart/values.yaml
+++ b/keycloak-chart/values.yaml
@@ -1,7 +1,7 @@
 app-template:
   global:
-  security:
-    allowInsecureImages: true
+    security:
+      allowInsecureImages: true
     fullnameOverride: keycloak
     namespaceOverride: datev-wallet
     labels:


### PR DESCRIPTION
This pull request updates container images for the application, as detected by **Argo CD Image Updater**.

**Changes:**
- chore: updated image adorsys/keycloak-ssi-deployment from 'sha256:609b6526384becbb1a95a0c5f896f56cd88d712eff202a573cb4db2d21969d06' to 'sha256:21a27509e3eb863768f5cee03b838cf881574fa10e8faf35181fd798935f09d9'

Signed-off-by: Argo CD Image Updater <ci@adorsys.com>