### PR TITLE
Migrate from Bitnami PostgreSQL chart to other  PostgreSQL deployment alternatives

### DIFF
--- a/keycloak-chart/Chart.lock
+++ b/keycloak-chart/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 16.7.8
+- name: postgres
+  repository: oci://registry-1.docker.io/cloudpirates
+  version: 0.8.2
 - name: app-template
   repository: https://bjw-s-labs.github.io/helm-charts
   version: 4.0.1
-digest: sha256:42070ee8b7c6045d15ee07708cbe7a65ed6a42f4183b554cbe5f4022a7c66ee6
-generated: "2025-06-05T09:29:53.094488543+01:00"
+digest: sha256:986d44b5c004824bad13c0f1ee7f736777c300ee87bd8e9e94134846447a6732
+generated: "2025-10-13T16:59:48.666646772+01:00"

--- a/keycloak-chart/Chart.yaml
+++ b/keycloak-chart/Chart.yaml
@@ -24,9 +24,9 @@ version: 1.0.0
 appVersion: "26.0.7"
 
 dependencies:
-  - name: postgresql
-    version: "16.7.8"
-    repository: https://charts.bitnami.com/bitnami
+  - name: postgres
+    version: 0.8.2
+    repository: oci://registry-1.docker.io/cloudpirates
   - name: app-template
     version: 4.0.1
     repository: https://bjw-s-labs.github.io/helm-charts

--- a/keycloak-chart/values.yaml
+++ b/keycloak-chart/values.yaml
@@ -1,7 +1,3 @@
-global:
-  security:
-    allowInsecureImages: true
-
 app-template:
   global:
     fullnameOverride: keycloak
@@ -22,8 +18,8 @@ app-template:
       initContainers:
         wait-for-configmap:
           image:
-            repository: bitnami/kubectl
-            tag: latest
+            repository: portainer/kubectl-shell
+            tag: 2.33.2
             pullPolicy: IfNotPresent
           command:
           - sh
@@ -34,17 +30,17 @@ app-template:
             done
         wait-for-postgres:
           image:
-            repository: bitnami/kubectl
-            tag: latest
+            repository: portainer/kubectl-shell
+            tag: 2.33.2
             pullPolicy: IfNotPresent
           command:
           - sh
           - -c
           - |
-            until kubectl get svc keycloak-postgresql -n datev-wallet; do
+            until kubectl get svc keycloak-postgres -n datev-wallet; do
               echo "Waiting for PostgreSQL service..."; sleep 2;
             done
-            until kubectl exec -n datev-wallet keycloak-postgresql-0 -- pg_isready -U datevadmin -d keycloakdb; do
+            until kubectl exec -n datev-wallet keycloak-postgres-0 -- pg_isready -U datevadmin -d keycloakdb; do
               echo "Waiting for PostgreSQL to be ready..."; sleep 2;
             done
       containers:
@@ -112,29 +108,26 @@ app-template:
         hosts:
         - "*.eudi-adorsys.com"
         - "eudi-adorsys.com"
-# Postgresql Configuration
-postgresql:
+# Postgres Configuration
+postgres:
   enabled: true
   image:
     registry: docker.io
-    repository: bitnamilegacy/postgresql
-    tag: 17.4.0-debian-12-r2
+    repository: postgres
+    tag: "17.6"
   auth:
     database: keycloakdb
     username: datevadmin
     existingSecret: keycloak-secret
     secretKeys:
-      adminPasswordKey: KC_DB_PASSWORD
-      userPasswordKey: KC_DB_PASSWORD
-  primary:
-    persistence:
-      enabled: true
-      size: 8Gi
-      storageClass: high-performance
-      # storageClass: standard # minikube (local test)
+      passwordKey: KC_DB_PASSWORD
+  persistence:
+    enabled: true
+    size: 8Gi
+    storageClass: high-performance
   service:
-    ports:
-      postgresql: 5432
+    type: ClusterIP
+    port: 5432
 # External secrets
 externalSecret:
   metadata:

--- a/keycloak-chart/values.yaml
+++ b/keycloak-chart/values.yaml
@@ -110,11 +110,6 @@ app-template:
         - "eudi-adorsys.com"
 # Postgres Configuration
 postgres:
-  enabled: true
-  image:
-    registry: docker.io
-    repository: postgres
-    tag: "17.6"
   auth:
     database: keycloakdb
     username: datevadmin


### PR DESCRIPTION
## Summary
This PR migrates the PostgreSQL deployment from Bitnami charts to an alternative PostgreSQL configuration, removing the Bitnami-specific global configuration and simplifying the setup.
