### PR TITLE
Improve docker support for deliverable-new-repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ WORKDIR /opt/keycloak
 
 # Runtime dependencies required by helper scripts
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends gettext-base && \
+    apt-get install -y --no-install-recommends gettext-base curl jq && \
     rm -rf /var/lib/apt/lists/*
 
 # Create a non-privileged user
@@ -57,6 +57,8 @@ RUN chmod +x /opt/keycloak/docker-entrypoint.sh
 
 # Ensure proper permissions
 RUN chown -R keycloak:keycloak /opt/keycloak
+RUN mkdir /home/keycloak
+RUN chown -R keycloak:keycloak /home/keycloak
 
 # Switch to non-privileged user
 USER keycloak

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,10 @@ services:
       - db
     ports:
       - "${KEYCLOAK_HTTPS_PORT}:${KEYCLOAK_HTTPS_PORT}"
+      - ./target/keycloak-server.key.pem:/opt/keycloak/target/keycloak-server.key.pem
+      - ./target/keycloak-server.crt.pem:/opt/keycloak/target/keycloak-server.crt.pem
+      - ./target/kc_keystore.pkcs12:/opt/keycloak/target/kc_keystore.pkcs12
+      - ./target/cacerts:/opt/keycloak/target/cacerts
 
 volumes:
   db_data:

--- a/keycloak-ssi.sh
+++ b/keycloak-ssi.sh
@@ -40,6 +40,11 @@ determine_project_root() {
         echo "$script_dir"
         return
     fi
+    # Check if running inside container
+    if [[ -f "/opt/keycloak/src/utils/helper.sh" ]]; then
+        echo "/opt/keycloak"
+        return
+    fi
     # If installed, use XDG Base Directory
     local xdg_data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
     local project_root="$xdg_data_home/keycloak-ssi-deployment"

--- a/src/credentials/request_credential.sh
+++ b/src/credentials/request_credential.sh
@@ -54,7 +54,7 @@ success "User Access Token retrieved."
 # ===============================
 log "Requesting credential offer for '$CREDENTIAL_TYPE'..."
 
-CREDENTIAL_OFFER_LINK=$(curl -k -s "$KEYCLOAK_ADMIN_ADDR/realms/$KEYCLOAK_REALM/protocol/oid4vc/credential-offer-uri?credential_configuration_id=$CREDENTIAL_TYPE&user_id=$USERS_FRANCIS_NAME" \
+CREDENTIAL_OFFER_LINK=$(curl -k -s "$KEYCLOAK_ADMIN_ADDR/realms/$KEYCLOAK_REALM/protocol/oid4vc/credential-offer-uri?credential_configuration_id=$CREDENTIAL_TYPE&username=$USERS_FRANCIS_NAME" \
   -H "Authorization: Bearer $USER_ACCESS_TOKEN" \
   -H 'Accept: application/json' \
   -H 'Content-Type: application/json' | jq -r '"\(.issuer)\(.nonce)"')

--- a/src/deployment/1.oid4vci_test_deployment.sh
+++ b/src/deployment/1.oid4vci_test_deployment.sh
@@ -25,24 +25,42 @@ log "Keycloak is running (PID: $keycloak_pid)."
 # -----------------------------------------------------------------------------
 # Helper for executing kcadm
 # -----------------------------------------------------------------------------
-KCADM="$KEYCLOAK_INSTALL_DIR/bin/kcadm.sh"
-if [[ ! -x "$KCADM" ]]; then
-  error "kcadm.sh not found or not executable at: $KCADM"
+# If running in Docker, we need to execute kcadm inside the container
+if [[ "$keycloak_pid" == "docker:"* ]]; then
+    CONTAINER_ID="${keycloak_pid#docker:}"
+    KCADM_CMD=(docker exec -i $CONTAINER_ID /opt/keycloak/target/tools/keycloak-$KEYCLOAK_VERSION/bin/kcadm.sh)
+else
+    KCADM="$KEYCLOAK_INSTALL_DIR/bin/kcadm.sh"
+    if [[ ! -x "$KCADM" ]]; then
+      error "kcadm.sh not found or not executable at: $KCADM"
+    fi
+    KCADM_CMD=("$KCADM")
 fi
 
 # -----------------------------------------------------------------------------
 # Authenticate admin
 # -----------------------------------------------------------------------------
 log "Authenticating admin user..."
-"$KCADM" config truststore --trustpass "$SSL_TRUST_STORE_PASS" "$SSL_TRUST_STORE"
+if [[ "$keycloak_pid" == "docker:"* ]]; then
 "$KCADM" config credentials --server "$KEYCLOAK_ADMIN_ADDR" --realm master \
     --user "$KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME" --password "$KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD"
+    
+    CONTAINER_TRUSTSTORE="/opt/keycloak/target/cacerts"
+    
+    "${KCADM_CMD[@]}" config truststore --trustpass "$SSL_TRUST_STORE_PASS" "$CONTAINER_TRUSTSTORE"
+    "${KCADM_CMD[@]}" config credentials --server "$KEYCLOAK_ADMIN_ADDR" --realm master \
+        --user "$KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME" --password "$KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD"
+else
+    "${KCADM_CMD[@]}" config truststore --trustpass "$SSL_TRUST_STORE_PASS" "$SSL_TRUST_STORE"
+    "${KCADM_CMD[@]}" config credentials --server "$KEYCLOAK_ADMIN_ADDR" --realm master \
+        --user "$KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME" --password "$KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD"
+fi
 
 # -----------------------------------------------------------------------------
 # Create realm
 # -----------------------------------------------------------------------------
 log "Creating realm '$KEYCLOAK_REALM' (if not exists)..."
-"$KCADM" create realms -s realm="$KEYCLOAK_REALM" -s enabled=true >/dev/null 2>&1 || warn "Realm already exists; continuing."
+"${KCADM_CMD[@]}" create realms -s realm="$KEYCLOAK_REALM" -s enabled=true >/dev/null 2>&1 || warn "Realm already exists; continuing."
 
 # -----------------------------------------------------------------------------
 # Configure key providers
@@ -60,8 +78,14 @@ configure_key_provider() {
   if [[ ! -f "$json_template" ]]; then
     error "Key provider template not found: $json_template"
   fi
+  
+  # Adjust keystore path for container if needed
+  local keystore_path="$KEYSTORE_PATH"
+  if [[ "$keycloak_pid" == "docker:"* ]]; then
+      keystore_path="/opt/keycloak/target/kc_keystore.pkcs12"
+  fi
 
-  jq --arg keystore "$KEYSTORE_PATH" \
+  jq --arg keystore "$keystore_path" \
      --arg keystorePassword "$KEYSTORE_PASSWORD" \
      --arg keystoreType "$KEYSTORE_TYPE" \
      --arg keyAlias "$alias" \
@@ -78,7 +102,7 @@ register_key_provider() {
   local json_content="$2"
 
   local exists
-  exists=$("$KCADM" get components -r "$KEYCLOAK_REALM" --fields name \
+  exists=$("${KCADM_CMD[@]}" get components -r "$KEYCLOAK_REALM" --fields name \
             | jq -r --arg n "$name" '.[]? | select(.name == $n) | .id' | head -n1)
 
   if [[ -n "$exists" ]]; then
@@ -86,7 +110,7 @@ register_key_provider() {
     return 0
   fi
 
-  if ! echo "$json_content" | "$KCADM" create components -r "$KEYCLOAK_REALM" -o -f - >/dev/null 2>&1; then
+  if ! echo "$json_content" | "${KCADM_CMD[@]}" create components -r "$KEYCLOAK_REALM" -o -f - >/dev/null 2>&1; then
     warn "Failed to register key provider '$name'; it already exists."
   fi
 }
@@ -119,7 +143,7 @@ log "Custom key provider registration complete."
 # -----------------------------------------------------------------------------
 log "Updating realm attributes..."
 if [[ -f "$WORK_DIR/src/config/realm-attributes.json" ]]; then
-  cat "$WORK_DIR/src/config/realm-attributes.json" | "$KCADM" update realms/"$KEYCLOAK_REALM" -o -f - >/dev/null || error "Realm update failed"
+  cat "$WORK_DIR/src/config/realm-attributes.json" | "${KCADM_CMD[@]}" update realms/"$KEYCLOAK_REALM" -o -f - >/dev/null || error "Realm update failed"
 else
   warn "realm-attributes.json not found; skipping realm attribute update."
 fi
@@ -131,7 +155,7 @@ log "Creating client scopes..."
 if [[ -f "$WORK_DIR/src/config/client-scope-config.json" ]]; then
   CLIENT_SCOPES_CONFIG=$(jq --arg ISSUER_DID "$KEYCLOAK_ISSUER_DID" 'map(.attributes["vc.issuer_did"] = $ISSUER_DID)' "$WORK_DIR/src/config/client-scope-config.json")
   echo "$CLIENT_SCOPES_CONFIG" | jq -c '.[]' | while read -r scope; do
-    echo "$scope" | "$KCADM" create client-scopes -r "$KEYCLOAK_REALM" -f - >/dev/null 2>&1 || \
+    echo "$scope" | "${KCADM_CMD[@]}" create client-scopes -r "$KEYCLOAK_REALM" -f - >/dev/null 2>&1 || \
       warn "Client scope already exists; skipping."
   done
 else
@@ -172,7 +196,7 @@ if [[ -f "$CLIENTS_CONFIG_FILE" && -f "$CLIENT_SCOPE_CONFIG_FILE" ]]; then
          .attributes["post.logout.redirect.uris"] = ($TEST_CLIENT_URL + "##" + $TEST_CLIENT_URL + "/*")')
     fi
 
-    echo "$MODIFIED_CLIENT" | "$KCADM" create clients -r "$KEYCLOAK_REALM" -o -f - >/dev/null 2>&1 || \
+    echo "$MODIFIED_CLIENT" | "${KCADM_CMD[@]}" create clients -r "$KEYCLOAK_REALM" -o -f - >/dev/null 2>&1 || \
       warn "Client '$CLIENT_ID' already exists; skipping."
   done
 else

--- a/src/deployment/2.configure_user_4_account_client.sh
+++ b/src/deployment/2.configure_user_4_account_client.sh
@@ -13,36 +13,49 @@ init_script
 # Get admin token using environment variables for credentials
 # -----------------------------------------------------------------------------
 log "Obtaining admin token..."
-KCADM="$KEYCLOAK_INSTALL_DIR/bin/kcadm.sh"
-"$KCADM" config truststore --trustpass "$SSL_TRUST_STORE_PASS" "$SSL_TRUST_STORE"
-"$KCADM" config credentials --server "$KEYCLOAK_ADMIN_ADDR" --realm master --user "$KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME" --password "$KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD"
+keycloak_pid="$(get_keycloak_pid || true)"
+
+# Run command function is used so 
+if [[ "$keycloak_pid" == "docker:"* ]]; then
+    CONTAINER_ID="${keycloak_pid#docker:}"
+    KCADM_CMD=(docker exec -i $CONTAINER_ID /opt/keycloak/target/tools/keycloak-$KEYCLOAK_VERSION/bin/kcadm.sh)
+    CONTAINER_TRUSTSTORE="/opt/keycloak/target/cacerts"
+    
+    "${KCADM_CMD[@]}" config truststore --trustpass "$SSL_TRUST_STORE_PASS" "$CONTAINER_TRUSTSTORE"
+    "${KCADM_CMD[@]}" config credentials --server "$KEYCLOAK_ADMIN_ADDR" --realm master --user "$KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME" --password "$KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD"
+else
+    KCADM="$KEYCLOAK_INSTALL_DIR/bin/kcadm.sh"
+    KCADM_CMD=("$KCADM")
+    "${KCADM_CMD[@]}" config truststore --trustpass "$SSL_TRUST_STORE_PASS" "$SSL_TRUST_STORE"
+    "${KCADM_CMD[@]}" config credentials --server "$KEYCLOAK_ADMIN_ADDR" --realm master --user "$KEYCLOAK_BOOTSTRAP_ADMIN_USERNAME" --password "$KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD"
+fi
 success "Admin token obtained."
 
 # -----------------------------------------------------------------------------
 # Read the direct access property of the openid4vc-rest-api client
 # -----------------------------------------------------------------------------
 log "Reading direct access property of the openid4vc-rest-api client..."
-"$KCADM" get clients -r "$KEYCLOAK_REALM" -q clientId=openid4vc-rest-api --fields 'id,directAccessGrantsEnabled' || true
+"${KCADM_CMD[@]}" get clients -r "$KEYCLOAK_REALM" -q clientId=openid4vc-rest-api --fields 'id,directAccessGrantsEnabled' || true
 
 # -----------------------------------------------------------------------------
 # Store property ACC_CLIENT_ID in an environment variable
 # -----------------------------------------------------------------------------
-export ACC_CLIENT_ID=$("$KCADM" get clients -r "$KEYCLOAK_REALM" -q clientId=openid4vc-rest-api --fields id | jq -r '.[0].id')
+export ACC_CLIENT_ID=$("${KCADM_CMD[@]}" get clients -r "$KEYCLOAK_REALM" -q clientId=openid4vc-rest-api --fields id | jq -r '.[0].id')
 log "Stored openid4vc-rest-api Client ID: $ACC_CLIENT_ID"
 
 # -----------------------------------------------------------------------------
 # Enable direct grant on the openid4vc-rest-api client
 # -----------------------------------------------------------------------------
 log "Enabling direct grant on the openid4vc-rest-api client..."
-"$KCADM" update clients/$ACC_CLIENT_ID -r "$KEYCLOAK_REALM" -s directAccessGrantsEnabled=true -o --fields 'id,directAccessGrantsEnabled' || true
+"${KCADM_CMD[@]}" update clients/$ACC_CLIENT_ID -r "$KEYCLOAK_REALM" -s directAccessGrantsEnabled=true -o --fields 'id,directAccessGrantsEnabled' || true
 success "Direct grant enabled."
 
 # -----------------------------------------------------------------------------
 # Create a user named Francis
 # -----------------------------------------------------------------------------
 log "Creating user Francis if not exists..."
-if ! "$KCADM" get users -r "$KEYCLOAK_REALM" -q username=francis | jq -e '.[0].id' >/dev/null 2>&1; then
-  "$KCADM" create users -r "$KEYCLOAK_REALM" -s username=francis -s firstName=Francis -s lastName=Pouatcha -s email=fpo@mail.de -s enabled=true
+if ! "${KCADM_CMD[@]}" get users -r "$KEYCLOAK_REALM" -q username=francis | jq -e '.[0].id' >/dev/null 2>&1; then
+  "${KCADM_CMD[@]}" create users -r "$KEYCLOAK_REALM" -s username=francis -s firstName=Francis -s lastName=Pouatcha -s email=fpo@mail.de -s enabled=true
   success "User Francis created."
 else
   warn "User Francis already exists."
@@ -52,7 +65,7 @@ fi
 # Set password for Francis
 # -----------------------------------------------------------------------------
 log "Setting password for user Francis..."
-"$KCADM" set-password -r "$KEYCLOAK_REALM" --username "$USERS_FRANCIS_NAME" --new-password "$USERS_FRANCIS_PASSWORD" || true
+"${KCADM_CMD[@]}" set-password -r "$KEYCLOAK_REALM" --username "$USERS_FRANCIS_NAME" --new-password "$USERS_FRANCIS_PASSWORD" || true
 success "Password ensured for Francis."
 
 # -----------------------------------------------------------------------------

--- a/src/utils/helper.sh
+++ b/src/utils/helper.sh
@@ -22,7 +22,6 @@ error()   { printf "\n${RED}[ERROR]${NC} %s\n" "$*" >&2; exit 1; }
 success() { printf "\n${GREEN}[SUCCESS]${NC} %s\n" "$*"; }
 debug()   { printf "\n${BLUE}[DEBUG]${NC} %s\n" "$*"; }
 
-
 # -----------------------------------------------------------------------------
 # Environment Setup
 # -----------------------------------------------------------------------------
@@ -51,6 +50,12 @@ setup_environment() {
             # Move up
             search_dir="$parent"
         done
+
+        # Fallback for container environment
+        if [[ -z "${WORK_DIR:-}" ]] && [[ -f "/opt/keycloak/src/utils/helper.sh" ]]; then
+            WORK_DIR="/opt/keycloak"
+            export WORK_DIR
+        fi
 
         if [[ -z "${WORK_DIR:-}" ]]; then
             error "Could not determine project root. Run from within the repository."
@@ -206,6 +211,29 @@ inject_environment_variables() {
 # -----------------------------------------------------------------------------
 get_keycloak_pid() {
     local pid
+    # First check if running in Docker Compose
+    if command -v docker &>/dev/null && docker compose version &>/dev/null; then
+        # Check if the 'app' service is running in the current project
+        # We use the directory name as the project name by default in docker compose
+        # But better to use the compose file in the current directory
+        
+        local compose_file="$WORK_DIR/docker-compose.yml"
+        if [[ -f "$compose_file" ]]; then
+             # Try to find the container ID for the 'app' service
+            local container_id
+            container_id=$(docker compose -f "$compose_file" ps -q app 2>/dev/null)
+            
+            if [[ -n "$container_id" ]]; then
+                # Check if it's actually running
+                if docker ps -q --no-trunc | grep -q "$container_id"; then
+                    echo "docker:$container_id"
+                    return
+                fi
+            fi
+        fi
+    fi
+
+    # Fallback to local process check
     if command -v pgrep &>/dev/null; then
         pid=$(pgrep -f keycloak | head -n1 || true)
     else
@@ -223,20 +251,28 @@ stop_keycloak() {
     keycloak_pid="$(get_keycloak_pid || true)"
 
     if [[ -n "$keycloak_pid" ]]; then
-        log "Keycloak instance found (PID: $keycloak_pid). Shutting it down..."
-        if ! kill "$keycloak_pid"; then
-            return 1
+        if [[ "$keycloak_pid" == "docker:"* ]]; then
+            log "Keycloak running in Docker Compose. Stopping container..."
+            DOCKER_COMPOSE_COMMAND="$(detect_docker_compose)"
+            DOCKER_COMPOSE_FILE="${WORK_DIR}/docker-compose.yml"
+            eval "$DOCKER_COMPOSE_COMMAND -f \"$DOCKER_COMPOSE_FILE\" stop app" || warn "Failed to stop app container."
+            log "Keycloak container stopped."
+        else
+            log "Keycloak instance found (PID: $keycloak_pid). Shutting it down..."
+            if ! kill "$keycloak_pid"; then
+                return 1
+            fi
+            # Wait for process to terminate
+            sleep 2
+            if kill -0 "$keycloak_pid" 2>/dev/null; then
+                kill -9 "$keycloak_pid" 2>/dev/null || true
+                sleep 1
+            fi
+            if kill -0 "$keycloak_pid" 2>/dev/null; then
+                return 1
+            fi
+            log "Keycloak stopped."
         fi
-        # Wait for process to terminate
-        sleep 2
-        if kill -0 "$keycloak_pid" 2>/dev/null; then
-            kill -9 "$keycloak_pid" 2>/dev/null || true
-            sleep 1
-        fi
-        if kill -0 "$keycloak_pid" 2>/dev/null; then
-            return 1
-        fi
-        log "Keycloak stopped."
     else
         log "No running Keycloak instance found."
     fi
@@ -320,6 +356,14 @@ ensure_keycloak_crypto_materials() {
             cp "$KEYSTORE_PATH" "$keystore_cache"
         fi
     fi
+    
+    # Ensure permissions if running in Docker or as root
+    if [[ -f "$KEYSTORE_PATH" ]]; then
+        chmod 644 "$KEYSTORE_PATH"
+    fi
+    if [[ -f "$SSL_TRUST_STORE" ]]; then
+        chmod 644 "$SSL_TRUST_STORE"
+    fi
 }
 
 # -----------------------------------------------------------------------------
@@ -327,7 +371,7 @@ ensure_keycloak_crypto_materials() {
 # -----------------------------------------------------------------------------
 check_dependencies() {
     local missing_deps=()
-    for dep in openssl keytool jq figlet yq; do
+    for dep in openssl keytool jq yq; do
         if ! command -v "$dep" &>/dev/null; then
             missing_deps+=("$dep")
         fi

--- a/src/utils/import_kc_config.sh
+++ b/src/utils/import_kc_config.sh
@@ -39,6 +39,10 @@ fi
 # Run CLI JAR to import realm configuration
 # ---------------------------------------------------------------------------
 log "Running Keycloak Config CLI..."
+keycloak_pid="$(get_keycloak_pid || true)"
+if [[ "$keycloak_pid" == "docker:"* ]]; then
+    log "Keycloak is running in Docker. Proceeding with import from host..."
+fi
 cd "$WORK_DIR" && java -DCLIENT_SECRET="$CLIENTS_SECRET" \
      -DKEYCLOAK_ADMIN_ADDR="$KEYCLOAK_ADMIN_ADDR" \
      -DKEYSTORE_PASSWORD="$KEYSTORE_PASSWORD" \


### PR DESCRIPTION
Fixes #198 and #197 

This pull request introduces several improvements to support running Keycloak both locally and within Docker Compose containers. The changes ensure that scripts and configuration automatically detect the execution environment and adjust commands, file paths, and permissions accordingly. Additionally, it enhances the robustness of deployment and credential management scripts, and ensures required dependencies and files are handled correctly in both environments.

**Additional Docker and Container Support:**

* Scripts now detect if Keycloak is running inside Docker Compose and adjust commands to use `docker exec` as needed, including for `kcadm.sh` operations and file paths [[1]](diffhunk://#diff-4f0c727d32ca2a366aa8c51cd0bfd93e31cb9341406746eeab30e1f4fd152740R28-R63) [[2]](diffhunk://#diff-4f0c727d32ca2a366aa8c51cd0bfd93e31cb9341406746eeab30e1f4fd152740L64-R88) [[3]](diffhunk://#diff-4f0c727d32ca2a366aa8c51cd0bfd93e31cb9341406746eeab30e1f4fd152740L81-R113) [[4]](diffhunk://#diff-4f0c727d32ca2a366aa8c51cd0bfd93e31cb9341406746eeab30e1f4fd152740L122-R146) [[5]](diffhunk://#diff-4f0c727d32ca2a366aa8c51cd0bfd93e31cb9341406746eeab30e1f4fd152740L134-R158) [[6]](diffhunk://#diff-4f0c727d32ca2a366aa8c51cd0bfd93e31cb9341406746eeab30e1f4fd152740L175-R199) [[7]](diffhunk://#diff-1224319b20c36b145ae7ddfee872540a39a91da3b3e3b982bb5ca9c5d44b929dR16-R58) [[8]](diffhunk://#diff-1224319b20c36b145ae7ddfee872540a39a91da3b3e3b982bb5ca9c5d44b929dL55-R68) [[9]](diffhunk://#diff-edf3333f4010f04b863a3730d9111e24f30aafb5621fd67b41bebb8f0582fe22R42-R45).
* The `get_keycloak_pid` and `stop_keycloak` functions in `helper.sh` now detect and manage Keycloak instances running in Docker Compose [[1]](diffhunk://#diff-3a397c7ab03a9c0207c9aa54a20c73e1fc8e69ba50e7c06dff7925f6ab4aba47R214-R236) [[2]](diffhunk://#diff-3a397c7ab03a9c0207c9aa54a20c73e1fc8e69ba50e7c06dff7925f6ab4aba47R254-R260) [[3]](diffhunk://#diff-3a397c7ab03a9c0207c9aa54a20c73e1fc8e69ba50e7c06dff7925f6ab4aba47R275).
* The Dockerfile and `docker-compose.yml` have been updated to include additional runtime dependencies (`curl`, `jq`), ensure correct permissions and user home directory, and mount cryptographic materials into the container [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L38-R38) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R60-R61) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R23-R26).

**Environment Detection and Path Handling:**

* Scripts that determine the project root and set up the environment now include logic to handle containerized paths, ensuring correct resolution inside Docker [[1]](diffhunk://#diff-8ad7f8b80a1dce0bb215a6eca0e373bb0bd26d145b4150fcef0d5918954b633dR43-R47) [[2]](diffhunk://#diff-3a397c7ab03a9c0207c9aa54a20c73e1fc8e69ba50e7c06dff7925f6ab4aba47R54-R59).

**Credential and Keystore Management:**

* Keystore and truststore file permissions are set to be accessible in both local and container environments, and keystore paths are adjusted as needed for container usage [[1]](diffhunk://#diff-4f0c727d32ca2a366aa8c51cd0bfd93e31cb9341406746eeab30e1f4fd152740L64-R88) [[2]](diffhunk://#diff-3a397c7ab03a9c0207c9aa54a20c73e1fc8e69ba50e7c06dff7925f6ab4aba47R359-R374).
* The credential request script fixes a query parameter from `user_id` to `username` for compatibility. (Resolves, #198, see https://github.com/keycloak/keycloak/pull/44715)

**General Robustness and Cleanups:**

* Dependency checks have been updated to remove unnecessary tools (`figlet`), and minor formatting cleanups were applied [[1]](diffhunk://#diff-3a397c7ab03a9c0207c9aa54a20c73e1fc8e69ba50e7c06dff7925f6ab4aba47R359-R374) [[2]](diffhunk://#diff-3a397c7ab03a9c0207c9aa54a20c73e1fc8e69ba50e7c06dff7925f6ab4aba47L25).

These changes collectively improve the flexibility, reliability, and portability of the deployment scripts and environment setup for both local development and containerized deployments.