### PR TITLE
Add PoS-specific DATEV credential scopes with isolated Terraform state

### DIFF
--- a/infrastructure/terraform/README.md
+++ b/infrastructure/terraform/README.md
@@ -56,6 +56,7 @@ The main variables are defined in the root `variables.tf` and module-specific `v
 | `keycloak_url`           | Keycloak base URL                                     | `https://localhost:8443` |
 | `admin_password`         | Keycloak admin password (required; provide via tfvars/env) | none                     |
 | `realm`                  | Keycloak realm name used for the OID4VCI issuer       | `oid4vc-vci`             |
+| `enabled_scope_names`    | Optional allowlist of client scope names to apply     | `[]` (apply all scopes)  |
 | `status_list_server_url` | Base URL of the status list server                    | `https://statuslist.eudi-adorsys.com` |
 | `status_list_enabled`    | Turns status list support on or off for the realm     | `false`                  |
 
@@ -96,6 +97,11 @@ Files introduced/used for this:
 - `backend-dev.hcl`
   - Supplies the `dev`-specific configuration for the backend.
   - This file is expected to be `gitignored` and contains your account/bucket/table values.
+- `backend-pos.hcl`
+  - Supplies a separate backend state for the PoS realm.
+  - Prevents dev and PoS realms from replacing each other in one shared state.
+- `backend-dev.hcl.example` and `backend-pos.hcl.example`
+  - Templates for creating local backend files safely.
 
 Example `dev` backend settings (replace with yours in `backend-dev.hcl`):
 - S3 bucket: `<YOUR_S3_BUCKET_NAME>`
@@ -138,6 +144,7 @@ Optional (if you want the local toolkit to pre-configure a realm before running 
 ##### A) Configure the demo Keycloak
 From repo root:
 ```bash
+cp infrastructure/terraform/backend-dev.hcl.example infrastructure/terraform/backend-dev.hcl
 terraform -chdir=infrastructure/terraform init -backend-config=backend-dev.hcl -reconfigure
 cp infrastructure/terraform/secrets-dev.tfvars.example infrastructure/terraform/secrets-dev.tfvars
 # edit infrastructure/terraform/secrets-dev.tfvars with your environment values
@@ -157,6 +164,23 @@ terraform -chdir=infrastructure/terraform apply \
 ```
 
 Note: the Terraform Keycloak provider has `tls_insecure_skip_verify = true`, so self-signed HTTPS from local Keycloak should work.
+
+##### C) Configure a separate PoS realm
+Use a dedicated backend state (for example `backend-pos.hcl`) so PoS and dev realms do not replace each other.
+
+```bash
+cp infrastructure/terraform/backend-pos.hcl.example infrastructure/terraform/backend-pos.hcl
+cp infrastructure/terraform/secrets-pos.tfvars.example infrastructure/terraform/secrets-pos.tfvars
+# edit infrastructure/terraform/backend-pos.hcl and infrastructure/terraform/secrets-pos.tfvars
+terraform -chdir=infrastructure/terraform init -backend-config=backend-pos.hcl -reconfigure
+terraform -chdir=infrastructure/terraform apply -var-file=./secrets-pos.tfvars
+```
+
+To switch back to dev operations:
+
+```bash
+terraform -chdir=infrastructure/terraform init -backend-config=backend-dev.hcl -reconfigure
+```
 
 ### 1. Initialize Terraform
 
@@ -212,9 +236,12 @@ This ensures only the custom imported keys are active for OpenID4VCI operations.
 
 ### Extensible Credential Configuration
 
-The Terraform setup is designed to be fully extensible. It automatically discovers and configures all credential definitions (`*.json` files) located in the `jsons/scopes/` directory.
+The Terraform setup discovers credential definitions (`*.json` files) in `jsons/scopes/`.
 
-To add a new credential type, simply create a new JSON file in this directory. Terraform will automatically create the corresponding client scope and associate it with the clients.
+- If `enabled_scope_names` is empty, all discovered scopes are applied.
+- If `enabled_scope_names` is set, only listed scope names are applied.
+
+This is useful for realm-specific scope sets (for example keeping PoS-only scopes out of the dev realm).
 
 ### SAML Identity Provider Features
 

--- a/infrastructure/terraform/README.md
+++ b/infrastructure/terraform/README.md
@@ -57,6 +57,7 @@ The main variables are defined in the root `variables.tf` and module-specific `v
 | `admin_password`         | Keycloak admin password (required; provide via tfvars/env) | none                     |
 | `realm`                  | Keycloak realm name used for the OID4VCI issuer       | `oid4vc-vci`             |
 | `enabled_scope_names`    | Optional allowlist of client scope names to apply     | `[]` (apply all scopes)  |
+| `optional_client_scope_client_ids` | Optional list of client IDs that receive optional scopes | `[]` (all configured clients) |
 | `status_list_server_url` | Base URL of the status list server                    | `https://statuslist.eudi-adorsys.com` |
 | `status_list_enabled`    | Turns status list support on or off for the realm     | `false`                  |
 

--- a/infrastructure/terraform/backend-dev.hcl.example
+++ b/infrastructure/terraform/backend-dev.hcl.example
@@ -1,0 +1,5 @@
+bucket         = "<YOUR_DEV_STATE_S3_BUCKET>"
+key            = "terraform/keycloak-ssi/dev/terraform.tfstate"
+region         = "eu-central-1"
+dynamodb_table = "<YOUR_DEV_STATE_LOCK_TABLE>"
+encrypt        = true

--- a/infrastructure/terraform/backend-pos.hcl.example
+++ b/infrastructure/terraform/backend-pos.hcl.example
@@ -1,0 +1,5 @@
+bucket         = "<YOUR_POS_STATE_S3_BUCKET>"
+key            = "terraform/keycloak-ssi/pos/terraform.tfstate"
+region         = "eu-central-1"
+dynamodb_table = "<YOUR_POS_STATE_LOCK_TABLE>"
+encrypt        = true

--- a/infrastructure/terraform/jsons/scopes/client-scope-DatevCompanyCredential-1.json
+++ b/infrastructure/terraform/jsons/scopes/client-scope-DatevCompanyCredential-1.json
@@ -1,0 +1,373 @@
+{
+    "name": "DatevCompanyCredential1",
+    "description": "DATEV eG buyer / e-invoice demo profile (static claims)",
+    "protocol": "oid4vc",
+    "attributes": {
+      "vc.credential_configuration_id": "DatevCompanyCredential1",
+      "vc.credential_contexts": "datev_organization_vct_1",
+      "vc.credential_build_config.sd_jwt.visible_claims": "id,iat,nbf,exp,jti,",
+      "vc.credential_build_config.hash_algorithm": "sha-256",
+      "vc.supported_credential_types": "datev_organization_vct_1",
+      "vc.format": "dc+sd-jwt",
+      "include.in.openid.provider.metadata": "true",
+      "include.in.token.scope": "true",
+      "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"DATEV Unternehmensdaten\",\"description\":\"DATEV Unternehmensdaten für E-Rechnungsprozesse\",\"logo\":{\"uri\":\"https://wallet-app-metadata.s3.eu-north-1.amazonaws.com/datev_logo.png\",\"alt_text\":\"DATEV\"},\"background_image\":{\"uri\":\"https://wallet-app-metadata.s3.eu-north-1.amazonaws.com/eudiw_bg_datev_1024_645.png\"},\"background_color\":\"#f0f0f0\",\"text_color\":\"#000000\"}]",
+      "vc.cryptographic_binding_methods_supported": "jwk",
+      "vc.expiry_in_seconds": "31536000",
+      "vc.verifiable_credential_type": "datev_organization_vct_1",
+      "vc.include_in_metadata": "true",
+      "vc.credential_build_config.token_jws_type": "dc+sd-jwt",
+      "vc.credential_signing_alg": "ES256",
+      "display.on.consent.screen": "true",
+      "vc.sd_jwt.number_of_decoys": "2",
+      "vc.credential_identifier": "DatevCompanyCredential1"
+    },
+    "protocolMappers": [
+      {
+        "name": "id-mapper-kma",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "sub",
+          "staticValue": "datev-subject-001",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Subjekt-ID\"}]",
+          "vc.include_in_metadata": "false"
+        }
+      },
+      {
+        "name": "username-mapper-kma",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-user-attribute-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "username",
+          "userAttribute": "username",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Benutzername\"}]",
+          "vc.include_in_metadata": "false"
+        }
+      },
+      {
+        "name": "iat-oid4vc-issued-at-time-claim-mapper-kma",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-issued-at-time-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "iat",
+          "truncateToTimeUnit": "HOURS",
+          "valueSource": "COMPUTE"
+        }
+      },
+      {
+        "name": "nbf-oid4vc-issued-at-time-claim-mapper-kma",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-issued-at-time-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "nbf",
+          "valueSource": "COMPUTE"
+        }
+      },
+      {
+        "name": "datev-buyer-org-official-name",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_org_official_name",
+          "staticValue": "Rechnungsempfaenger_Lab_PoC_T",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Amtliche Firmenbezeichnung (Registername)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-org-unique-id",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_org_unique_id",
+          "staticValue": "5917949",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Einheitliche Kennung der Organisation (EUID/Alternative)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-org-euid",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_org_euid",
+          "staticValue": "N/A",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"European Unique Identifier (falls vorhanden)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-postal-address-street",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_postal_address_street",
+          "staticValue": "Fürther Str. 244",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Strasse/Hausnr. (Rechnungsadresse)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-postal-address-postcode",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_postal_address_postcode",
+          "staticValue": "90329",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Postleitzahl\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-postal-address-city",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_postal_address_city",
+          "staticValue": "Nürnberg",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Ort\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-postal-address-country",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_postal_address_country_code",
+          "staticValue": "DE",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Ländercode (Käuferadresse)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-tax-vat-id",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_tax_vat_id",
+          "staticValue": "DE 133546770",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Umsatzsteuer-Identifikationsnummer Käufer\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-reference",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_reference",
+          "staticValue": "6789",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Buyer Reference / Kostenstelle / PO\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-contact-email",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_contact_email",
+          "staticValue": "Rechnungsempfaenger_Lab_PoC@datev.de",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Kontakt E-Mail\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-routing-peppol-id",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_routing_peppol_id",
+          "staticValue": "N/A",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Peppol Participant ID (Empfang)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-routing-traffiqx-id",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_routing_traffiqx_id",
+          "staticValue": "TX:0012000736141",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Traffiqx Participant ID (Empfang)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-routing-preferred-channel",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_routing_preferred_channel",
+          "staticValue": "TRAFFIQX",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Bevorzugter Zustellkanal\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-routing-email",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_routing_email",
+          "staticValue": "28ae25b48d044edfb3614ee76da949e7@in.e-rechnung.datev.de",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Fallback E-Mail (falls zulässig)\"}]"
+        }
+      },
+      {
+        "name": "datev-empfaengerwunschformat",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "Empfängerwunschformat",
+          "staticValue": "X-Rechnung",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Empfängerwunschformat (X-Rechnung, ZUGFeRD, Peppol Bis Billing)\"}]"
+        }
+      },
+      {
+        "name": "datev-handelsname-kaeufers",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "Handelsname_des_Käufers",
+          "staticValue": "DATEV LAB",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Firmenname\"}]"
+        }
+      },
+      {
+        "name": "datev-beraternummer",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "Beraternummer",
+          "staticValue": "129420",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Beraternummer\"}]"
+        }
+      },
+      {
+        "name": "datev-mandantennummer",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "Mandantennummer",
+          "staticValue": "25801",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Mandantennummer\"}]"
+        }
+      },
+      {
+        "name": "datev-mydatev-postfach",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "MyDATEVPostfach",
+          "staticValue": "Eingangsrechnung",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"MyDATEVPostfach\"}]"
+        }
+      },
+      {
+        "name": "datev-employee-person-id",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "employee_person_id",
+          "staticValue": "123",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Eindeutige Personen-/Mitarbeiter-ID\"}]"
+        }
+      },
+      {
+        "name": "datev-employee-authorization-role",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "employee_authorization_role",
+          "staticValue": "FB",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Rolle/Funktion\"}]"
+        }
+      },
+      {
+        "name": "datev-employee-authorization-limit-amount",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "employee_authorization_limit_amount",
+          "staticValue": "10,000",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Limit (Single/Daily)\"}]"
+        }
+      },
+      {
+        "name": "datev-employee-authorization-validity",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "employee_authorization_validity",
+          "staticValue": "12/31/2026",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Gültigkeitszeitraum\"}]"
+        }
+      },
+      {
+        "name": "datev-employee-authorization-issuer-signature",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "employee_authorization_issuer_signature",
+          "staticValue": "N/A",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Issuer/Signatur/Revocation\"}]"
+        }
+      },
+      {
+        "name": "datev-employee-acts-for-org-unique",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "employee_acts_for_org_unique",
+          "staticValue": "Rechnungsempfaenger_Lab_PoC_T",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Mandatsbezug zur Organisation\"}]"
+        }
+      }
+    ]
+  }
+  

--- a/infrastructure/terraform/jsons/scopes/client-scope-DatevCompanyCredential-2.json
+++ b/infrastructure/terraform/jsons/scopes/client-scope-DatevCompanyCredential-2.json
@@ -1,0 +1,373 @@
+{
+    "name": "DatevCompanyCredential2",
+    "description": "DATEV eG buyer / e-invoice demo profile (static claims)",
+    "protocol": "oid4vc",
+    "attributes": {
+      "vc.credential_configuration_id": "DatevCompanyCredential2",
+      "vc.credential_contexts": "datev_organization_vct_2",
+      "vc.credential_build_config.sd_jwt.visible_claims": "id,iat,nbf,exp,jti,",
+      "vc.credential_build_config.hash_algorithm": "sha-256",
+      "vc.supported_credential_types": "datev_organization_vct_2",
+      "vc.format": "dc+sd-jwt",
+      "include.in.openid.provider.metadata": "true",
+      "include.in.token.scope": "true",
+      "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"DATEV Unternehmensdaten\",\"description\":\"DATEV Unternehmensdaten für E-Rechnungsprozesse\",\"logo\":{\"uri\":\"https://wallet-app-metadata.s3.eu-north-1.amazonaws.com/datev_logo.png\",\"alt_text\":\"DATEV\"},\"background_image\":{\"uri\":\"https://wallet-app-metadata.s3.eu-north-1.amazonaws.com/eudiw_bg_datev_1024_645.png\"},\"background_color\":\"#f0f0f0\",\"text_color\":\"#000000\"}]",
+      "vc.cryptographic_binding_methods_supported": "jwk",
+      "vc.expiry_in_seconds": "31536000",
+      "vc.verifiable_credential_type": "datev_organization_vct_2",
+      "vc.include_in_metadata": "true",
+      "vc.credential_build_config.token_jws_type": "dc+sd-jwt",
+      "vc.credential_signing_alg": "ES256",
+      "display.on.consent.screen": "true",
+      "vc.sd_jwt.number_of_decoys": "2",
+      "vc.credential_identifier": "DatevCompanyCredential2"
+    },
+    "protocolMappers": [
+      {
+        "name": "id-mapper-kma",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "sub",
+          "staticValue": "datev-subject-002",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Subjekt-ID\"}]",
+          "vc.include_in_metadata": "false"
+        }
+      },
+      {
+        "name": "username-mapper-kma",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-user-attribute-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "username",
+          "userAttribute": "username",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Benutzername\"}]",
+          "vc.include_in_metadata": "false"
+        }
+      },
+      {
+        "name": "iat-oid4vc-issued-at-time-claim-mapper-kma",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-issued-at-time-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "iat",
+          "truncateToTimeUnit": "HOURS",
+          "valueSource": "COMPUTE"
+        }
+      },
+      {
+        "name": "nbf-oid4vc-issued-at-time-claim-mapper-kma",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-issued-at-time-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "nbf",
+          "valueSource": "COMPUTE"
+        }
+      },
+      {
+        "name": "datev-buyer-org-official-name",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_org_official_name",
+          "staticValue": "Rechnungsempfaenger_Lab_PoC_P",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Amtliche Firmenbezeichnung (Registername)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-org-unique-id",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_org_unique_id",
+          "staticValue": "5917949",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Einheitliche Kennung der Organisation (EUID/Alternative)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-org-euid",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_org_euid",
+          "staticValue": "N/A",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"European Unique Identifier (falls vorhanden)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-postal-address-street",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_postal_address_street",
+          "staticValue": "Fürther Str. 244",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Strasse/Hausnr. (Rechnungsadresse)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-postal-address-postcode",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_postal_address_postcode",
+          "staticValue": "90329",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Postleitzahl\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-postal-address-city",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_postal_address_city",
+          "staticValue": "Nürnberg",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Ort\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-postal-address-country",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_postal_address_country_code",
+          "staticValue": "DE",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Ländercode (Käuferadresse)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-tax-vat-id",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_tax_vat_id",
+          "staticValue": "DE 133546770",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Umsatzsteuer-Identifikationsnummer Käufer\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-reference",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_reference",
+          "staticValue": "6789",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Buyer Reference / Kostenstelle / PO\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-contact-email",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_contact_email",
+          "staticValue": "Rechnungsempfaenger_Lab_PoC@datev.de",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Kontakt E-Mail\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-routing-peppol-id",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_routing_peppol_id",
+          "staticValue": "9918:DE80700500000004513154",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Peppol Participant ID (Empfang)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-routing-traffiqx-id",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_routing_traffiqx_id",
+          "staticValue": "N/A",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Traffiqx Participant ID (Empfang)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-routing-preferred-channel",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_routing_preferred_channel",
+          "staticValue": "Peppol",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Bevorzugter Zustellkanal\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-routing-email",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_routing_email",
+          "staticValue": "28ae25b48d044edfb3614ee76da949e7@in.e-rechnung.datev.de",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Fallback E-Mail (falls zulässig)\"}]"
+        }
+      },
+      {
+        "name": "datev-empfaengerwunschformat",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "Empfängerwunschformat",
+          "staticValue": "ZUGFeRD",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Empfängerwunschformat (X-Rechnung, ZUGFeRD, Peppol Bis Billing)\"}]"
+        }
+      },
+      {
+        "name": "datev-handelsname-kaeufers",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "Handelsname_des_Käufers",
+          "staticValue": "DATEV LAB",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Firmenname\"}]"
+        }
+      },
+      {
+        "name": "datev-beraternummer",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "Beraternummer",
+          "staticValue": "129420",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Beraternummer\"}]"
+        }
+      },
+      {
+        "name": "datev-mandantennummer",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "Mandantennummer",
+          "staticValue": "25801",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Mandantennummer\"}]"
+        }
+      },
+      {
+        "name": "datev-mydatev-postfach",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "MyDATEVPostfach",
+          "staticValue": "Eingangsrechnung",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"MyDATEVPostfach\"}]"
+        }
+      },
+      {
+        "name": "datev-employee-person-id",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "employee_person_id",
+          "staticValue": "123",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Eindeutige Personen-/Mitarbeiter-ID\"}]"
+        }
+      },
+      {
+        "name": "datev-employee-authorization-role",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "employee_authorization_role",
+          "staticValue": "FB",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Rolle/Funktion\"}]"
+        }
+      },
+      {
+        "name": "datev-employee-authorization-limit-amount",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "employee_authorization_limit_amount",
+          "staticValue": "10,000",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Limit (Single/Daily)\"}]"
+        }
+      },
+      {
+        "name": "datev-employee-authorization-validity",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "employee_authorization_validity",
+          "staticValue": "12/31/2026",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Gültigkeitszeitraum\"}]"
+        }
+      },
+      {
+        "name": "datev-employee-authorization-issuer-signature",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "employee_authorization_issuer_signature",
+          "staticValue": "N/A",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Issuer/Signatur/Revocation\"}]"
+        }
+      },
+      {
+        "name": "datev-employee-acts-for-org-unique",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "employee_acts_for_org_unique",
+          "staticValue": "Rechnungsempfaenger_Lab_PoC_P",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Mandatsbezug zur Organisation\"}]"
+        }
+      }
+    ]
+  }
+  

--- a/infrastructure/terraform/jsons/scopes/client-scope-DatevCompanyCredential-3.json
+++ b/infrastructure/terraform/jsons/scopes/client-scope-DatevCompanyCredential-3.json
@@ -1,0 +1,373 @@
+{
+    "name": "DatevCompanyCredential3",
+    "description": "DATEV eG buyer / e-invoice demo profile (static claims)",
+    "protocol": "oid4vc",
+    "attributes": {
+      "vc.credential_configuration_id": "DatevCompanyCredential3",
+      "vc.credential_contexts": "datev_organization_vct_3",
+      "vc.credential_build_config.sd_jwt.visible_claims": "id,iat,nbf,exp,jti,",
+      "vc.credential_build_config.hash_algorithm": "sha-256",
+      "vc.supported_credential_types": "datev_organization_vct_3",
+      "vc.format": "dc+sd-jwt",
+      "include.in.openid.provider.metadata": "true",
+      "include.in.token.scope": "true",
+      "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"DATEV Unternehmensdaten\",\"description\":\"DATEV Unternehmensdaten für E-Rechnungsprozesse\",\"logo\":{\"uri\":\"https://wallet-app-metadata.s3.eu-north-1.amazonaws.com/datev_logo.png\",\"alt_text\":\"DATEV\"},\"background_image\":{\"uri\":\"https://wallet-app-metadata.s3.eu-north-1.amazonaws.com/eudiw_bg_datev_1024_645.png\"},\"background_color\":\"#f0f0f0\",\"text_color\":\"#000000\"}]",
+      "vc.cryptographic_binding_methods_supported": "jwk",
+      "vc.expiry_in_seconds": "31536000",
+      "vc.verifiable_credential_type": "datev_organization_vct_3",
+      "vc.include_in_metadata": "true",
+      "vc.credential_build_config.token_jws_type": "dc+sd-jwt",
+      "vc.credential_signing_alg": "ES256",
+      "display.on.consent.screen": "true",
+      "vc.sd_jwt.number_of_decoys": "2",
+      "vc.credential_identifier": "DatevCompanyCredential3"
+    },
+    "protocolMappers": [
+      {
+        "name": "id-mapper-kma",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "sub",
+          "staticValue": "datev-subject-003",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Subjekt-ID\"}]",
+          "vc.include_in_metadata": "false"
+        }
+      },
+      {
+        "name": "username-mapper-kma",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-user-attribute-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "username",
+          "userAttribute": "username",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Benutzername\"}]",
+          "vc.include_in_metadata": "false"
+        }
+      },
+      {
+        "name": "iat-oid4vc-issued-at-time-claim-mapper-kma",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-issued-at-time-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "iat",
+          "truncateToTimeUnit": "HOURS",
+          "valueSource": "COMPUTE"
+        }
+      },
+      {
+        "name": "nbf-oid4vc-issued-at-time-claim-mapper-kma",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-issued-at-time-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "nbf",
+          "valueSource": "COMPUTE"
+        }
+      },
+      {
+        "name": "datev-buyer-org-official-name",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_org_official_name",
+          "staticValue": "Rechnungsempfaenger_Lab_PoC_M",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Amtliche Firmenbezeichnung (Registername)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-org-unique-id",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_org_unique_id",
+          "staticValue": "5917949",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Einheitliche Kennung der Organisation (EUID/Alternative)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-org-euid",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_org_euid",
+          "staticValue": "N/A",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"European Unique Identifier (falls vorhanden)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-postal-address-street",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_postal_address_street",
+          "staticValue": "Fürther Str. 244",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Strasse/Hausnr. (Rechnungsadresse)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-postal-address-postcode",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_postal_address_postcode",
+          "staticValue": "90329",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Postleitzahl\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-postal-address-city",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_postal_address_city",
+          "staticValue": "Nürnberg",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Ort\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-postal-address-country",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_postal_address_country_code",
+          "staticValue": "DE",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Ländercode (Käuferadresse)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-tax-vat-id",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_tax_vat_id",
+          "staticValue": "DE 133546770",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Umsatzsteuer-Identifikationsnummer Käufer\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-reference",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_reference",
+          "staticValue": "6789",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Buyer Reference / Kostenstelle / PO\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-contact-email",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_contact_email",
+          "staticValue": "Rechnungsempfaenger_Lab_PoC@datev.de",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Kontakt E-Mail\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-routing-peppol-id",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_routing_peppol_id",
+          "staticValue": "N/A",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Peppol Participant ID (Empfang)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-routing-traffiqx-id",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_routing_traffiqx_id",
+          "staticValue": "N/A",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Traffiqx Participant ID (Empfang)\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-routing-preferred-channel",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_routing_preferred_channel",
+          "staticValue": "Mail",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Bevorzugter Zustellkanal\"}]"
+        }
+      },
+      {
+        "name": "datev-buyer-routing-email",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "buyer_routing_email",
+          "staticValue": "28ae25b48d044edfb3614ee76da949e7@in.e-rechnung.datev.de",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Fallback E-Mail (falls zulässig)\"}]"
+        }
+      },
+      {
+        "name": "datev-empfaengerwunschformat",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "Empfängerwunschformat",
+          "staticValue": "PePPol Bis Billing",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Empfängerwunschformat (X-Rechnung, ZUGFeRD, Peppol Bis Billing)\"}]"
+        }
+      },
+      {
+        "name": "datev-handelsname-kaeufers",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "Handelsname_des_Käufers",
+          "staticValue": "DATEV LAB",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Firmenname\"}]"
+        }
+      },
+      {
+        "name": "datev-beraternummer",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "Beraternummer",
+          "staticValue": "129420",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Beraternummer\"}]"
+        }
+      },
+      {
+        "name": "datev-mandantennummer",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "Mandantennummer",
+          "staticValue": "25801",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Mandantennummer\"}]"
+        }
+      },
+      {
+        "name": "datev-mydatev-postfach",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "MyDATEVPostfach",
+          "staticValue": "Eingangsrechnung",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"MyDATEVPostfach\"}]"
+        }
+      },
+      {
+        "name": "datev-employee-person-id",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "employee_person_id",
+          "staticValue": "123",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Eindeutige Personen-/Mitarbeiter-ID\"}]"
+        }
+      },
+      {
+        "name": "datev-employee-authorization-role",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "employee_authorization_role",
+          "staticValue": "FB",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Rolle/Funktion\"}]"
+        }
+      },
+      {
+        "name": "datev-employee-authorization-limit-amount",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "employee_authorization_limit_amount",
+          "staticValue": "10,000",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Limit (Single/Daily)\"}]"
+        }
+      },
+      {
+        "name": "datev-employee-authorization-validity",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "employee_authorization_validity",
+          "staticValue": "12/31/2026",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Gültigkeitszeitraum\"}]"
+        }
+      },
+      {
+        "name": "datev-employee-authorization-issuer-signature",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "employee_authorization_issuer_signature",
+          "staticValue": "N/A",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Issuer/Signatur/Revocation\"}]"
+        }
+      },
+      {
+        "name": "datev-employee-acts-for-org-unique",
+        "protocol": "oid4vc",
+        "protocolMapper": "oid4vc-static-claim-mapper",
+        "consentRequired": false,
+        "config": {
+          "claim.name": "employee_acts_for_org_unique",
+          "staticValue": "Rechnungsempfaenger_Lab_PoC_M",
+          "vc.mandatory": "false",
+          "vc.display": "[{\"locale\":\"de-DE\",\"name\":\"Mandatsbezug zur Organisation\"}]"
+        }
+      }
+    ]
+  }
+  

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -106,6 +106,7 @@ module "clients" {
   keycloak_url             = var.keycloak_url
   clients                  = local.clients
   optional_client_scopes   = local.configured_scope_names
+  optional_client_scope_client_ids = var.optional_client_scope_client_ids
   client_scopes_dependency = module.client_scopes.client_scopes_applied_trigger
   depends_on               = [module.realm, module.client_scopes]
 }

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -33,17 +33,22 @@ locals {
     }
   }
 
-  # Keep authenticator VCTs aligned with all configured OID4VC client scopes.
-  configured_scope_files = fileset("${path.root}/jsons/scopes", "*.json")
-  configured_scope_vcts = sort(distinct(compact([
-    for scope_file in local.configured_scope_files :
-    try(jsondecode(file("${path.root}/jsons/scopes/${scope_file}")).attributes["vc.verifiable_credential_type"], null)
-  ])))
-
-  configured_scope_names = sort(distinct(compact([
-    for scope_file in local.configured_scope_files :
-    try(jsondecode(file("${path.root}/jsons/scopes/${scope_file}")).name, null)
-  ])))
+  # Keep authenticator VCTs aligned with selected OID4VC client scopes.
+  available_scope_files = fileset("${path.root}/jsons/scopes", "*.json")
+  available_scope_records = [
+    for scope_file in local.available_scope_files : {
+      file = scope_file
+      name = try(jsondecode(file("${path.root}/jsons/scopes/${scope_file}")).name, null)
+      vct  = try(jsondecode(file("${path.root}/jsons/scopes/${scope_file}")).attributes["vc.verifiable_credential_type"], null)
+    }
+  ]
+  selected_scope_records = length(var.enabled_scope_names) == 0 ? local.available_scope_records : [
+    for record in local.available_scope_records : record
+    if record.name != null && contains(var.enabled_scope_names, record.name)
+  ]
+  configured_scope_files = sort(distinct(compact([for record in local.selected_scope_records : record.file])))
+  configured_scope_names = sort(distinct(compact([for record in local.selected_scope_records : record.name])))
+  configured_scope_vcts  = sort(distinct(compact([for record in local.selected_scope_records : record.vct])))
 
 }
 
@@ -86,6 +91,7 @@ module "client_scopes" {
   realm_name     = var.realm
   admin_password = urlencode(var.admin_password)
   keycloak_url   = var.keycloak_url
+  scope_files    = local.configured_scope_files
 }
 
 module "clients" {

--- a/infrastructure/terraform/modules/client_scopes/main.tf
+++ b/infrastructure/terraform/modules/client_scopes/main.tf
@@ -7,8 +7,8 @@ terraform {
 }
 
 locals {
-  # Find all .json files in the scopes directory
-  client_scope_files = fileset("${path.root}/jsons/scopes", "*.json")
+  # When explicit scope files are provided, apply only those; otherwise apply all JSON scopes.
+  client_scope_files = length(var.scope_files) > 0 ? toset(var.scope_files) : toset(fileset("${path.root}/jsons/scopes", "*.json"))
 }
 
 resource "null_resource" "apply_custom_oid4vc_client_scopes" {

--- a/infrastructure/terraform/modules/client_scopes/variables.tf
+++ b/infrastructure/terraform/modules/client_scopes/variables.tf
@@ -17,3 +17,9 @@ variable "keycloak_url" {
   description = "Keycloak base URL"
   type        = string
 }
+
+variable "scope_files" {
+  description = "List of client scope JSON filenames (from jsons/scopes) to apply."
+  type        = list(string)
+  default     = []
+}

--- a/infrastructure/terraform/modules/clients/main.tf
+++ b/infrastructure/terraform/modules/clients/main.tf
@@ -6,6 +6,13 @@ terraform {
   }
 }
 
+locals {
+  scope_assignment_clients = length(var.optional_client_scope_client_ids) == 0 ? keycloak_openid_client.clients : {
+    for client_id, client in keycloak_openid_client.clients : client_id => client
+    if contains(var.optional_client_scope_client_ids, client_id)
+  }
+}
+
 
 resource "keycloak_openid_client" "clients" {
   for_each = var.clients
@@ -73,7 +80,7 @@ resource "null_resource" "apply_client_attributes" {
 }
 
 resource "null_resource" "apply_optional_scopes" {
-  for_each = keycloak_openid_client.clients
+  for_each = local.scope_assignment_clients
 
   depends_on = [null_resource.apply_client_attributes]
 

--- a/infrastructure/terraform/modules/clients/variables.tf
+++ b/infrastructure/terraform/modules/clients/variables.tf
@@ -45,3 +45,9 @@ variable "optional_client_scopes" {
   description = "List of optional client scope names to assign to each client"
   type        = list(string)
 }
+
+variable "optional_client_scope_client_ids" {
+  description = "Client IDs that should receive optional client scopes. If empty, scopes are assigned to all configured clients."
+  type        = list(string)
+  default     = []
+}

--- a/infrastructure/terraform/modules/keys/main.tf
+++ b/infrastructure/terraform/modules/keys/main.tf
@@ -41,20 +41,20 @@ resource "null_resource" "apply_custom_oid4vc_key_components" {
 
       if [ "${var.enable_rsa_keys}" = "true" ]; then
         # Import RSA issuer key
-        echo '${local.rsa_issuer_key_json}' | curl -k -s -X POST "$KC_URL/admin/realms/${var.realm_name}/components" \
+        echo '${local.rsa_issuer_key_json}' | jq --arg realm "${var.realm_name}" '.parentId = $realm' | curl -k -s -X POST "$KC_URL/admin/realms/${var.realm_name}/components" \
           -H "Authorization: Bearer $TOKEN" \
           -H "Content-Type: application/json" \
           --data-binary @-
 
         # Import RSA encryption key
-        echo '${local.rsa_encryption_key_json}' | curl -k -s -X POST "$KC_URL/admin/realms/${var.realm_name}/components" \
+        echo '${local.rsa_encryption_key_json}' | jq --arg realm "${var.realm_name}" '.parentId = $realm' | curl -k -s -X POST "$KC_URL/admin/realms/${var.realm_name}/components" \
           -H "Authorization: Bearer $TOKEN" \
           -H "Content-Type: application/json" \
           --data-binary @-
       fi
 
       # Import ECDSA issuer key
-      echo '${local.ecdsa_issuer_key_json}' | curl -k -s -X POST "$KC_URL/admin/realms/${var.realm_name}/components" \
+      echo '${local.ecdsa_issuer_key_json}' | jq --arg realm "${var.realm_name}" '.parentId = $realm' | curl -k -s -X POST "$KC_URL/admin/realms/${var.realm_name}/components" \
         -H "Authorization: Bearer $TOKEN" \
         -H "Content-Type: application/json" \
         --data-binary @-

--- a/infrastructure/terraform/secrets-dev.tfvars.example
+++ b/infrastructure/terraform/secrets-dev.tfvars.example
@@ -34,3 +34,10 @@ enabled_scope_names = [
   "SteuerberaterCredential"
 ]
 
+# Optional: attach OID4VC credential scopes only to selected clients.
+# Current oid4vc-vci setup uses both demo public and confidential API clients.
+optional_client_scope_client_ids = [
+  "oid4vc-demo-public",
+  "openid4vc-rest-api"
+]
+

--- a/infrastructure/terraform/secrets-pos.tfvars.example
+++ b/infrastructure/terraform/secrets-pos.tfvars.example
@@ -1,8 +1,9 @@
-# Copy to `secrets-dev.tfvars` (gitignored) and fill in the real values.
+# Copy to `secrets-pos.tfvars` (gitignored) and fill in the real values.
 #
-# IMPORTANT: Do NOT commit `secrets-dev.tfvars`.
+# IMPORTANT: Do NOT commit `secrets-pos.tfvars`.
 
 keycloak_url = "https://keycloak-demo.eudi-adorsys.com"
+realm        = "oid4vc-pos"
 
 # Kubernetes secret `keycloak-secret` (in namespace `datev-wallet`) contains:
 # - KC_BOOTSTRAP_ADMIN_PASSWORD
@@ -22,15 +23,11 @@ enable_rsa_keys = false
 
 # Optional: issuer root display metadata (realm attribute: oid4vci.display).
 # Must be a JSON array string.
-oid4vci_display = "[{\"name\":\"DATEV Unternehmensdaten\",\"locale\":\"de-DE\",\"logo\":{\"uri\":\"https://wallet-app-metadata.s3.eu-north-1.amazonaws.com/adorsys-logo-primary.png\",\"alt_text\":\"DATEV\"}}]"
+oid4vci_display = "[{\"name\":\"PoS Unternehmensdaten\",\"locale\":\"de-DE\",\"logo\":{\"uri\":\"https://wallet-app-metadata.s3.eu-north-1.amazonaws.com/datev_logo.png\",\"alt_text\":\"PoS\"}}]"
 
-# Optional but recommended: pin dev realm scopes so PoS-only scopes are not applied to dev.
+# Apply only the PoS scope set.
 enabled_scope_names = [
-  "BankEmployeeCredential",
-  "CityRegistryCredential",
-  "DatevCompanyCredential",
-  "IdentityCredential",
-  "KMACredential",
-  "SteuerberaterCredential"
+  "DatevCompanyCredential1",
+  "DatevCompanyCredential2",
+  "DatevCompanyCredential3"
 ]
-

--- a/infrastructure/terraform/secrets-pos.tfvars.example
+++ b/infrastructure/terraform/secrets-pos.tfvars.example
@@ -31,3 +31,10 @@ enabled_scope_names = [
   "DatevCompanyCredential2",
   "DatevCompanyCredential3"
 ]
+
+# Optional: attach OID4VC credential scopes only to selected clients.
+# PoS can use both demo public and confidential API clients.
+optional_client_scope_client_ids = [
+  "oid4vc-demo-public",
+  "openid4vc-rest-api"
+]

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -134,3 +134,9 @@ variable "oid4vci_display" {
   type        = string
   default     = ""
 }
+
+variable "optional_client_scope_client_ids" {
+  description = "Client IDs that should receive optional OID4VC client scopes. Empty list applies scopes to all configured clients."
+  type        = list(string)
+  default     = []
+}

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -16,6 +16,12 @@ variable "realm" {
   default     = "oid4vc-vci"
 }
 
+variable "enabled_scope_names" {
+  description = "Optional allowlist of OID4VC client scope names to apply. Empty list means all scopes in jsons/scopes."
+  type        = list(string)
+  default     = []
+}
+
 variable "oid4vc_demo_public_valid_redirect_uris" {
   description = "Valid redirect URIs for the oid4vc-demo-public client."
   type        = list(string)


### PR DESCRIPTION
## Summary

- add realm-aware client scope filtering via `enabled_scope_names` so each realm can apply only selected scopes
- add PoS credential variants `DatevCompanyCredential1/2/3` with unique scope names, credential IDs, and VCTs to avoid metadata conflicts
- update PoS/dev Terraform docs and examples, including separate backend templates and `secrets-pos.tfvars.example`, plus explicit dev scope pinning

## What changed
- Terraform scope selection:
  - `variables.tf`: new `enabled_scope_names` allowlist variable
  - `main.tf`: compute selected scope files/names/VCTs from allowlist (fallback to all when empty)
  - `modules/client_scopes`: accept `scope_files` input and apply only those files
- PoS scope files:
  - updated `client-scope-DatevCompanyCredential-1.json`
  - updated `client-scope-DatevCompanyCredential-2.json`
  - updated `client-scope-DatevCompanyCredential-3.json`
  - ensured unique:
    - `name`
    - `vc.credential_configuration_id`
    - `vc.credential_identifier`
    - `vc.credential_contexts` / `vc.supported_credential_types` / `vc.verifiable_credential_type`
- Environment split and examples:
  - add `backend-dev.hcl.example`
  - add `backend-pos.hcl.example`
  - add `secrets-pos.tfvars.example`
  - update `secrets-dev.tfvars.example` with explicit non-PoS `enabled_scope_names`
  - update `README.md` with PoS backend/state workflow and scope-selection documentation
 